### PR TITLE
Fix/performance and leak

### DIFF
--- a/src/kafka-pubsub.ts
+++ b/src/kafka-pubsub.ts
@@ -27,7 +27,8 @@ interface SubscriptionsMap {
 export class KafkaPubSub implements PubSubEngine {
   private client: Kafka;
   private subscriptionMap: SubscriptionsMap;
-  private channelSubscriptions: { [channel: string]: number[] };
+  private lastId: number = 0;
+  private channelSubscriptions: { [channel: string]: Set<number> };
   private producer: Producer;
   private consumer: Consumer;
   private topic: string;
@@ -83,7 +84,7 @@ export class KafkaPubSub implements PubSubEngine {
     payload: string | Buffer,
     headers?: IHeaders,
     sendOptions?: object,
-    key?: string | Buffer,
+    key?: string | Buffer
   ): Promise<void> {
     await this.producer.send({
       messages: [
@@ -106,19 +107,18 @@ export class KafkaPubSub implements PubSubEngine {
     onMessage: MessageHandler,
     _?: any
   ): Promise<number> {
-    const index = Object.keys(this.subscriptionMap).length;
-    this.subscriptionMap[index] = [channel, onMessage];
+    this.lastId = this.lastId + 1;
+    this.subscriptionMap[this.lastId] = [channel, onMessage];
     this.channelSubscriptions[channel] = (
-      this.channelSubscriptions[channel] || []
-    ).concat(index);
-    return index;
+      this.channelSubscriptions[channel] || new Set()
+    ).add(this.lastId);
+    return this.lastId;
   }
 
   public unsubscribe(index: number) {
     const [channel] = this.subscriptionMap[index];
-    this.channelSubscriptions[channel] = this.channelSubscriptions[
-      channel
-    ].filter((subId) => subId !== index);
+    this.channelSubscriptions[channel].delete(index);
+    this.subscriptionMap[index] = undefined;
   }
 
   public asyncIterator<T>(triggers: string | string[]): AsyncIterator<T> {
@@ -130,10 +130,10 @@ export class KafkaPubSub implements PubSubEngine {
     if (!subscriptions) {
       return;
     } // no subscribers, don't publish msg
-    for (const subId of subscriptions) {
+    subscriptions.forEach((subId) => {
       const [cnl, listener] = this.subscriptionMap[subId];
       listener(message);
-    }
+    });
   }
 
   private async connectProducer() {

--- a/src/test/kafka-pubsub.spec.ts
+++ b/src/test/kafka-pubsub.spec.ts
@@ -24,6 +24,7 @@ describe("Test Suite", () => {
       headers: { channel },
     });
   });
+
   it("should test basic pub sub with stringified payload", async () => {
     const topic = "mock_topic";
     const channel = "my_channel";
@@ -45,6 +46,7 @@ describe("Test Suite", () => {
       headers: { channel },
     });
   });
+
   it("should test basic pub sub with custom headers", async () => {
     const topic = "mock_topic";
     const channel = "my_channel";
@@ -71,6 +73,7 @@ describe("Test Suite", () => {
       },
     });
   });
+
   it("should test basic pub sub with custom key", async () => {
     const topic = "mock_topic";
     const channel = "my_channel";
@@ -96,5 +99,90 @@ describe("Test Suite", () => {
         channel,
       },
     });
+  });
+
+  it("should increment the id for each subscription", async () => {
+    const topic = "mock_topic";
+    const channel = "my_channel";
+
+    const onMessage = jest.fn((msg: KafkaMessage) => {});
+
+    const pubsub = await KafkaPubSub.create({
+      groupIdPrefix: "my-prefix",
+      kafka: new Kafka() as any,
+      topic,
+    });
+
+    const id1 = await pubsub.subscribe(channel, onMessage);
+    const id2 = await pubsub.subscribe(channel, onMessage);
+
+    expect(id1).toBe(1);
+    expect(id2).toBe(2);
+  });
+
+  it("should notify all subscriptions", async () => {
+    const topic = "mock_topic";
+    const channel = "my_channel";
+    const payload = Buffer.from(JSON.stringify({ data: 1 }));
+
+    const onMessage = jest.fn((msg: KafkaMessage) => {});
+    const onMessage2 = jest.fn((msg: KafkaMessage) => {});
+
+    const pubsub = await KafkaPubSub.create({
+      groupIdPrefix: "my-prefix",
+      kafka: new Kafka() as any,
+      topic,
+    });
+
+    await pubsub.subscribe(channel, onMessage);
+    await pubsub.subscribe(channel, onMessage2);
+
+    await pubsub.publish(channel, payload);
+
+    expect(onMessage).toBeCalled();
+    expect(onMessage2).toBeCalled();
+  });
+
+  it("should unsubscribe the given subscription", async () => {
+    const topic = "mock_topic";
+    const channel = "my_channel";
+    const payload = Buffer.from(JSON.stringify({ data: 1 }));
+
+    const onMessage = jest.fn((msg: KafkaMessage) => {});
+
+    const pubsub = await KafkaPubSub.create({
+      groupIdPrefix: "my-prefix",
+      kafka: new Kafka() as any,
+      topic,
+    });
+
+    const id = await pubsub.subscribe(channel, onMessage);
+
+    pubsub.unsubscribe(id);
+    await pubsub.publish(channel, payload);
+
+    expect(onMessage).not.toBeCalled();
+  });
+
+  it("should only unsubscribe the given subscription", async () => {
+    const topic = "mock_topic";
+    const channel = "my_channel";
+    const payload = Buffer.from(JSON.stringify({ data: 1 }));
+
+    const onMessage = jest.fn((msg: KafkaMessage) => {});
+
+    const pubsub = await KafkaPubSub.create({
+      groupIdPrefix: "my-prefix",
+      kafka: new Kafka() as any,
+      topic,
+    });
+
+    const id = await pubsub.subscribe(channel, onMessage);
+    await pubsub.subscribe(channel, onMessage);
+
+    pubsub.unsubscribe(id);
+    await pubsub.publish(channel, payload);
+
+    expect(onMessage).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
unsubscribe didn't remove the index from the map
subscribe needed to create an array of all keys to get the next index
the map used arrays to store all indexes, replaced with a Set for faster lookup
Added tests before the fix to verify it still works fine
Tested performance of adding 100K subscribers and publishing a message:
new implementation: 85ms
old implementation: 120 sec
